### PR TITLE
Add Module Definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
 - 1.9.x
 - 1.10.x
+- 1.11beta2
 go_import_path: github.com/sclevine/spec
 script:
-- go test ./...
+- env GO111MODULE=on go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/sclevine/spec


### PR DESCRIPTION
This PR adds a `go.mod` file, turning the package into a go module. This sets the stage for an initial release for `spec` to be cut, by tagging this commit with a version like `v0.1.0`.