### PR TITLE
Major feature: Suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,34 @@ With less nesting:
 
 ```go
 func TestObject(t *testing.T) {
-    spec.Run(t, "object", testObject)
+    spec.Run(t, "object", testObject, spec.Report(report.Terminal{}))
 }
 
 func testObject(t *testing.T, when spec.G, it spec.S) {
-    var someObject myapp.Object
     ...
+}
+```
+
+For focusing/reporting across multiple files in a package:
+
+```go
+var suite spec.Suite
+
+func init() {
+    suite = spec.New("my suite", spec.Report(report.Terminal{}))
+    suite("object", testObject)
+    suite("other object", testOtherObject)
+}
+
+func TestObjects(t *testing.T) {
+	suite.Run(t)
+}
+
+func testObject(t *testing.T, when spec.G, it spec.S) {
+	...
+}
+
+func testOtherObject(t *testing.T, when spec.G, it spec.S) {
+	...
 }
 ```

--- a/options.go
+++ b/options.go
@@ -1,6 +1,9 @@
 package spec
 
-import "io"
+import (
+	"io"
+	"testing"
+)
 
 // An Option is used to control the behavior of a call to Run, G, or S.
 // Options are inherited by subgroups and subspecs.
@@ -179,6 +182,7 @@ type config struct {
 	focus  bool
 	before bool
 	after  bool
+	run    *testing.T
 	out    func(io.Writer)
 	report Reporter
 }

--- a/options.go
+++ b/options.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-// An Option is used to control the behavior of a call to Run, G, or S.
+// An Option controls the behavior of a suite, group, or spec.
 // Options are inherited by subgroups and subspecs.
 //
 // Example:
@@ -19,7 +19,8 @@ type Option func(*config)
 
 // Report specifies a Reporter for a suite.
 //
-// Valid Option for: Run
+// Valid Option for:
+// New, Run, Focus, Pend
 func Report(r Reporter) Option {
 	return func(c *config) {
 		c.report = r
@@ -30,7 +31,8 @@ func Report(r Reporter) Option {
 // The random seed is always displayed before specs are run.
 // If not specified, the current time is used.
 //
-// Valid Option for: Run
+// Valid Option for:
+// New, Run, Focus, Pend
 func Seed(s int64) Option {
 	return func(c *config) {
 		c.seed = s
@@ -40,7 +42,8 @@ func Seed(s int64) Option {
 // Sequential indicates that a group of specs should be run in order.
 // This is the default behavior.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Sequential() Option {
 	return func(c *config) {
 		c.order = orderSequential
@@ -50,7 +53,8 @@ func Sequential() Option {
 // Random indicates that a group of specs should be run in random order.
 // Randomization is per group, such that all groupings are maintained.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Random() Option {
 	return func(c *config) {
 		c.order = orderRandom
@@ -59,7 +63,8 @@ func Random() Option {
 
 // Reverse indicates that a group of specs should be run in reverse order.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Reverse() Option {
 	return func(c *config) {
 		c.order = orderReverse
@@ -69,7 +74,8 @@ func Reverse() Option {
 // Parallel indicates that a spec or group of specs should be run in parallel.
 // This Option is equivalent to t.Parallel().
 //
-// Valid Option for: Run, G, S
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend, S
 func Parallel() Option {
 	return func(c *config) {
 		c.order = orderParallel
@@ -82,7 +88,8 @@ func Parallel() Option {
 // different subgroups will not be interleaved.
 // This is the default behavior.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Local() Option {
 	return func(c *config) {
 		c.scope = scopeLocal
@@ -94,7 +101,8 @@ func Local() Option {
 // specs in random order, regardless of subgroup. Specs in different subgroups
 // may be interleaved.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Global() Option {
 	return func(c *config) {
 		c.scope = scopeGlobal
@@ -104,7 +112,8 @@ func Global() Option {
 // Flat indicates that a parent subtest should not be created for the group.
 // This is the default behavior.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Flat() Option {
 	return func(c *config) {
 		c.nest = nestOff
@@ -114,7 +123,8 @@ func Flat() Option {
 // Nested indicates that a parent subtest should be created for the group.
 // This allows for more control over parallelism.
 //
-// Valid Option for: Run, G
+// Valid Option for:
+// New, Run, Focus, Pend, Suite, Suite.Focus, Suite.Pend, G, G.Focus, G.Pend
 func Nested() Option {
 	return func(c *config) {
 		c.nest = nestOn

--- a/options.go
+++ b/options.go
@@ -182,7 +182,7 @@ type config struct {
 	focus  bool
 	before bool
 	after  bool
-	run    *testing.T
+	t      *testing.T
 	out    func(io.Writer)
 	report Reporter
 }

--- a/parser.go
+++ b/parser.go
@@ -21,7 +21,7 @@ type node struct {
 func (n *node) parse(f func(*testing.T, G, S)) Plan {
 	// TODO: validate Options
 	plan := Plan{
-		Text: n.text[0],
+		Text: strings.Join(n.text, "/"),
 		Seed: n.seed,
 	}
 	f(nil, func(text string, f func(), opts ...Option) {

--- a/spec.go
+++ b/spec.go
@@ -11,29 +11,30 @@ import (
 // Unlike other testing libraries, it is re-evaluated for each subspec.
 //
 // Valid Options:
-// Sequential(), Random(), Reverse(), Parallel()
-// Local(), Global(), Flat(), Nested()
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
 type G func(text string, f func(), opts ...Option)
 
-// Pend skips all specs in the group.
+// Pend skips all specs in the provided group.
 //
 // All Options are ignored.
 func (g G) Pend(text string, f func(), _ ...Option) {
 	g(text, f, func(c *config) { c.pend = true })
 }
 
-// Focus skips all specs except the focused group and other focused specs.
+// Focus focuses the provided group.
+// This skips all specs in the suite except the group and other focused specs.
 //
 // Valid Options:
-// Sequential(), Random(), Reverse(), Parallel()
-// Local(), Global(), Flat(), Nested()
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
 func (g G) Focus(text string, f func(), opts ...Option) {
 	g(text, f, append(opts, func(c *config) { c.focus = true })...)
 }
 
 // S defines a spec.
 //
-// Valid Options: Parallel()
+// Valid Options: Parallel
 type S func(text string, f func(), opts ...Option)
 
 // Before runs a function before each spec in the group.
@@ -46,16 +47,17 @@ func (s S) After(f func()) {
 	s("", f, func(c *config) { c.after = true })
 }
 
-// Pend skips the spec.
+// Pend skips the provided spec.
 //
 // All Options are ignored.
 func (s S) Pend(text string, f func(), _ ...Option) {
 	s(text, f, func(c *config) { c.pend = true })
 }
 
-// Focus skips all specs except the focused spec and other focused specs.
+// Focus focuses the provided spec.
+// This skips all specs in the suite except the spec and other focused specs.
 //
-// Valid Options: Parallel()
+// Valid Options: Parallel
 func (s S) Focus(text string, f func(), opts ...Option) {
 	s(text, f, append(opts, func(c *config) { c.focus = true })...)
 }
@@ -74,36 +76,85 @@ func (s S) Out() io.Writer {
 	return out
 }
 
+// Suite defines a top-level group of specs within a suite.
+// Suite behaves like a top-level version of G.
+// Unlike other testing libraries, it is re-evaluated for each subspec.
+//
+// Valid Options:
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
 type Suite func(text string, f func(*testing.T, G, S), opts ...Option) bool
 
+// Before runs a function before each spec in the suite.
 func (s Suite) Before(f func(*testing.T)) bool {
 	return s("", func(t *testing.T, _ G, _ S) { f(t) }, func(c *config) { c.before = true })
 }
 
+// After runs a function after each spec in the suite.
 func (s Suite) After(f func(*testing.T)) bool {
 	return s("", func(t *testing.T, _ G, _ S) { f(t) }, func(c *config) { c.after = true })
 }
 
+// Pend skips the provided top-level group of specs.
+//
+// All Options are ignored.
 func (s Suite) Pend(text string, f func(*testing.T, G, S), _ ...Option) bool {
 	return s(text, f, func(c *config) { c.pend = true })
 }
 
+// Focus focuses the provided top-level group.
+// This skips all specs in the suite except the group and other focused specs.
+//
+// Valid Options:
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
 func (s Suite) Focus(text string, f func(*testing.T, G, S), opts ...Option) bool {
 	return s(text, f, append(opts, func(c *config) { c.focus = true })...)
 }
 
+// Run executes the specs defined in each top-level group of the suite.
 func (s Suite) Run(t *testing.T) bool {
 	return s("", nil, func(c *config) { c.t = t })
 }
 
+// New creates an empty suite and returns an Suite function.
+// The Suite function may be called to add top-level groups to the suite.
+// The suite may be executed with Suite.Run.
+//
+// Valid Options:
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
+// Seed, Report
 func New(text string, opts ...Option) Suite {
-	type suite struct {
-		text string
-		f    func(*testing.T, G, S)
-		opts []Option
+	var fs []func(*testing.T, G, S)
+	return func(newText string, f func(*testing.T, G, S), newOpts ...Option) bool {
+		cfg := options(newOpts).apply()
+		if cfg.t == nil {
+			fs = append(fs, func(t *testing.T, g G, s S) {
+				var do func(string, func(), ...Option) = g
+				if cfg.before || cfg.after {
+					do = s
+				}
+				do(newText, func() { f(t, g, s) }, newOpts...)
+			})
+			return true
+		}
+		return Run(cfg.t, text, func(t *testing.T, g G, s S) {
+			for _, f := range fs {
+				f(t, g, s)
+			}
+		}, opts...)
 	}
-	var suites []suite
+}
 
+// Run immediately executes the provided specs as a suite.
+// Unlike other testing libraries, it is re-evaluated for each spec.
+//
+// Valid Options:
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
+// Seed, Report
+func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bool {
 	cfg := options(opts).apply()
 	n := &node{
 		text:  []string{text},
@@ -115,115 +166,91 @@ func New(text string, opts ...Option) Suite {
 		focus: cfg.focus,
 	}
 	report := cfg.report
+	plan := n.parse(f)
 
-	return func(text string, f func(*testing.T, G, S), opts ...Option) bool {
-		if f != nil {
-			suites = append(suites, suite{text, f, opts})
-			return true
-		}
-
-		t := options(opts).apply().t
-		if len(suites) == 1 && suites[0].text == "" && len(suites[0].opts) == 0 {
-			f = suites[0].f
-		} else {
-			f = func(t *testing.T, g G, s S) {
-				for _, st := range suites {
-					cfg := options(st.opts).apply()
-					if cfg.before || cfg.after {
-						s("", func () { st.f(t, nil, nil) }, st.opts...)
-					} else {
-						g(st.text, func() { st.f(t, g, s) }, st.opts...)
-					}
-				}
-			}
-		}
-
-		plan := n.parse(f)
-
-		var specs chan Spec
-		if report != nil {
-			report.Start(t, plan)
-			specs = make(chan Spec, plan.Total)
-			done := make(chan struct{})
-			defer func() {
-				close(specs)
-				<-done
-			}()
-			go func() {
-				report.Specs(t, specs)
-				close(done)
-			}()
-		}
-
-		return n.run(t, func(t *testing.T, n node) {
-			buffer := &bytes.Buffer{}
-			defer func() {
-				if specs == nil {
-					return
-				}
-				specs <- Spec{
-					Text:     n.text,
-					Failed:   t.Failed(),
-					Skipped:  t.Skipped(),
-					Focused:  n.focus,
-					Parallel: n.order == orderParallel,
-					Out:      buffer,
-				}
-			}()
-			switch {
-			case n.pend, plan.HasFocus && !n.focus:
-				t.SkipNow()
-			case n.order == orderParallel:
-				t.Parallel()
-			}
-			var (
-				spec, group   func()
-				before, after []func()
-				afterIdx      int
-			)
-			group = func() {}
-
-			f(t, func(_ string, f func(), _ ...Option) {
-				switch {
-				case len(n.loc) == 1, n.loc[0] > 0:
-					n.loc[0]--
-				case n.loc[0] == 0:
-					group = func() {
-						n.loc = n.loc[1:]
-						afterIdx = 0
-						group = func() {}
-						f()
-						group()
-					}
-					n.loc[0]--
-				}
-			}, func(_ string, f func(), opts ...Option) {
-				cfg := options(opts).apply()
-				switch {
-				case cfg.out != nil:
-					cfg.out(buffer)
-				case cfg.before:
-					before = append(before, f)
-				case cfg.after:
-					after = insert(after, f, afterIdx)
-					afterIdx++
-				case spec != nil:
-				case len(n.loc) > 1, n.loc[0] > 0:
-					n.loc[0]--
-				default:
-					spec = f
-				}
-			})
-			group()
-
-			if spec == nil {
-				t.Fatal("Failed to locate spec.")
-			}
-			run(before...)
-			defer run(after...)
-			run(spec)
-		})
+	var specs chan Spec
+	if report != nil {
+		report.Start(t, plan)
+		specs = make(chan Spec, plan.Total)
+		done := make(chan struct{})
+		defer func() {
+			close(specs)
+			<-done
+		}()
+		go func() {
+			report.Specs(t, specs)
+			close(done)
+		}()
 	}
+
+	return n.run(t, func(t *testing.T, n node) {
+		buffer := &bytes.Buffer{}
+		defer func() {
+			if specs == nil {
+				return
+			}
+			specs <- Spec{
+				Text:     n.text,
+				Failed:   t.Failed(),
+				Skipped:  t.Skipped(),
+				Focused:  n.focus,
+				Parallel: n.order == orderParallel,
+				Out:      buffer,
+			}
+		}()
+		switch {
+		case n.pend, plan.HasFocus && !n.focus:
+			t.SkipNow()
+		case n.order == orderParallel:
+			t.Parallel()
+		}
+		var (
+			spec, group   func()
+			before, after []func()
+			afterIdx      int
+		)
+		group = func() {}
+
+		f(t, func(_ string, f func(), _ ...Option) {
+			switch {
+			case len(n.loc) == 1, n.loc[0] > 0:
+				n.loc[0]--
+			case n.loc[0] == 0:
+				group = func() {
+					n.loc = n.loc[1:]
+					afterIdx = 0
+					group = func() {}
+					f()
+					group()
+				}
+				n.loc[0]--
+			}
+		}, func(_ string, f func(), opts ...Option) {
+			cfg := options(opts).apply()
+			switch {
+			case cfg.out != nil:
+				cfg.out(buffer)
+			case cfg.before:
+				before = append(before, f)
+			case cfg.after:
+				after = insert(after, f, afterIdx)
+				afterIdx++
+			case spec != nil:
+			case len(n.loc) > 1, n.loc[0] > 0:
+				n.loc[0]--
+			default:
+				spec = f
+			}
+		})
+		group()
+
+		if spec == nil {
+			t.Fatal("Failed to locate spec.")
+		}
+		run(before...)
+		defer run(after...)
+		run(spec)
+	})
 }
 
 func run(fs ...func()) {
@@ -239,31 +266,20 @@ func insert(fs []func(), f func(), i int) []func() {
 	return fs
 }
 
-// Run defines a suite, which is a top-level group of specs.
-// Unlike other testing libraries, it is re-evaluated for each spec.
-//
-// Valid Options:
-// Sequential(), Random(), Reverse(), Parallel()
-// Local(), Global(), Flat(), Nested()
-func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bool {
-	suite := New(text, opts...)
-	suite("", f)
-	return suite.Run(t)
-}
-
-// Pend skips the suite.
+// Pend skips all specs in the top-level group.
 //
 // All Options are ignored.
 func Pend(t *testing.T, text string, f func(*testing.T, G, S), _ ...Option) bool {
 	return Run(t, text, f, func(c *config) { c.pend = true })
 }
 
-// Focus focuses every spec in the suite.
+// Focus focuses every spec in the provided suite.
 // This is useful as a shortcut for unfocusing all focused specs.
 //
 // Valid Options:
-// Sequential(), Random(), Reverse(), Parallel()
-// Local(), Global(), Flat(), Nested()
+// Sequential, Random, Reverse, Parallel
+// Local, Global, Flat, Nested
+// Seed, Report
 func Focus(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bool {
 	return Run(t, text, f, append(opts, func(c *config) { c.focus = true })...)
 }

--- a/spec.go
+++ b/spec.go
@@ -117,12 +117,12 @@ func New(text string, opts ...Option) Suite {
 	report := cfg.report
 
 	return func(text string, f func(*testing.T, G, S), opts ...Option) bool {
-		cfg := options(opts).apply()
-		if cfg.t == nil {
+		if f != nil {
 			suites = append(suites, suite{text, f, opts})
 			return true
 		}
 
+		t := options(opts).apply().t
 		if len(suites) == 1 && suites[0].text == "" && len(suites[0].opts) == 0 {
 			f = suites[0].f
 		} else {
@@ -142,7 +142,7 @@ func New(text string, opts ...Option) Suite {
 
 		var specs chan Spec
 		if report != nil {
-			report.Start(cfg.t, plan)
+			report.Start(t, plan)
 			specs = make(chan Spec, plan.Total)
 			done := make(chan struct{})
 			defer func() {
@@ -150,12 +150,12 @@ func New(text string, opts ...Option) Suite {
 				<-done
 			}()
 			go func() {
-				report.Specs(cfg.t, specs)
+				report.Specs(t, specs)
 				close(done)
 			}()
 		}
 
-		return n.run(cfg.t, func(t *testing.T, n node) {
+		return n.run(t, func(t *testing.T, n node) {
 			buffer := &bytes.Buffer{}
 			defer func() {
 				if specs == nil {


### PR DESCRIPTION
- Adds "global" focusing
- Adds "global" reporting
- Make other `Option`s global (e.g., test order)
- Doesn't introduce any global state 😄 
- No breaking changes to the API

~**Note:** this is an untested prototype~

---

Usage:
```go
suite := spec.New("my suite", myreporter)

var _ = suite("my object", func(t *testing.T, when spec.G, it spec.S) {
...
}, spec.Random())

var _ = suite("my other object", func(t *testing.T, when spec.G, it spec.S) {
...
}, spec.Parallel())

func TestObject(t *testing.T) {
  suite.Run(t)
}
```
Or better:
```go
var suite spec.Suite

func init() {
  suite = spec.New("my suite", myreporter)
  suite("my object", testMyObject spec.Random())
  suite("my other object", testMyOtherObject, spec.Parallel())
}

func testMyObject(t *testing.T, when spec.G, it spec.S) {
...
}

func testMyOtherObject(t *testing.T, when spec.G, it spec.S) {
...
}

func TestObjects(t *testing.T) {
  suite.Run(t)
}
```