### PR TITLE
be more concise when logging test failures

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -126,6 +126,7 @@ func (n *node) nested() bool {
 }
 
 func (n node) run(t *testing.T, f func(*testing.T, node)) bool {
+	t.Helper()
 	name := strings.Join(n.text, "/")
 	switch {
 	case n.nodes == nil:
@@ -140,6 +141,7 @@ func (n node) run(t *testing.T, f func(*testing.T, node)) bool {
 type tree []node
 
 func (ns tree) run(t *testing.T, f func(*testing.T, node)) bool {
+	t.Helper()
 	ok := true
 	for _, n := range ns {
 		ok = n.run(t, f) && ok

--- a/spec.go
+++ b/spec.go
@@ -155,6 +155,7 @@ func New(text string, opts ...Option) Suite {
 // Local, Global, Flat, Nested
 // Seed, Report
 func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bool {
+	t.Helper()
 	cfg := options(opts).apply()
 	n := &node{
 		text:  []string{text},
@@ -184,6 +185,7 @@ func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bo
 	}
 
 	return n.run(t, func(t *testing.T, n node) {
+		t.Helper()
 		buffer := &bytes.Buffer{}
 		defer func() {
 			if specs == nil {
@@ -247,13 +249,14 @@ func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bo
 		if spec == nil {
 			t.Fatal("Failed to locate spec.")
 		}
-		run(before...)
-		defer run(after...)
-		run(spec)
+		run(t, before...)
+		defer run(t, after...)
+		run(t, spec)
 	})
 }
 
-func run(fs ...func()) {
+func run(t *testing.T, fs ...func()) {
+	t.Helper()
 	for _, f := range fs {
 		f()
 	}
@@ -270,6 +273,7 @@ func insert(fs []func(), f func(), i int) []func() {
 //
 // All Options are ignored.
 func Pend(t *testing.T, text string, f func(*testing.T, G, S), _ ...Option) bool {
+	t.Helper()
 	return Run(t, text, f, func(c *config) { c.pend = true })
 }
 
@@ -281,6 +285,7 @@ func Pend(t *testing.T, text string, f func(*testing.T, G, S), _ ...Option) bool
 // Local, Global, Flat, Nested
 // Seed, Report
 func Focus(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bool {
+	t.Helper()
 	return Run(t, text, f, append(opts, func(c *config) { c.focus = true })...)
 }
 


### PR DESCRIPTION
When tests fail, there is a fair bit of information included in the stack trace that is not actually helpful in identifying the actual line of test code that led to a failure.

`testing.T` provides a `Helper()` function that can be used to mark a function as a test helper. This PR invokes `t.Helper()` in various places that should probably not show up in the stack trace.