### PR TITLE
Print test summary in red in case of a test failure

### DIFF
--- a/report/terminal.go
+++ b/report/terminal.go
@@ -8,6 +8,8 @@ import (
 	"github.com/sclevine/spec"
 )
 
+const ErrorColor = "\u001b[31m%s\033[0m"
+
 // Terminal reports specs via stdout.
 type Terminal struct{}
 
@@ -47,5 +49,11 @@ func (Terminal) Specs(_ *testing.T, specs <-chan spec.Spec) {
 			}
 		}
 	}
-	fmt.Printf("\nPassed: %d | Failed: %d | Skipped: %d\n\n", passed, failed, skipped)
+
+	report := fmt.Sprintf("Passed: %d | Failed: %d | Skipped: %d\n\n", passed, failed, skipped)
+	if failed == 0 {
+		fmt.Printf("\n" + report)
+	} else {
+		fmt.Printf(ErrorColor, report)
+	}
 }


### PR DESCRIPTION
You may want to use the [color package](github.com/fatih/color) from fatih instead. 

This change will help me quickly determine if a test failure occurred. It would be better if the actual error message was in red as well, but something like this could be a good start.

Don't merge it if you hate it. Just an idea.