### PR TITLE
updates travis to newer go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 go:
-- 1.9.x
-- 1.10.x
 - 1.11.x
+- 1.12.x
 go_import_path: github.com/sclevine/spec
 script:
 - env GO111MODULE=on go test ./...


### PR DESCRIPTION
Hey from DigitalOcean @sclevine!

I had been looking for a project to use this on and I finally found a good fit in:

https://github.com/digitalocean/doctl/pull/549

Any pointers on organization with the library let me know.

Otherwise:

Wanted to drop 1.9 which is deprecated and bring in 1.12 (should be fine).