### PR TITLE
Defer 'after' block before any hook execution

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -257,8 +257,8 @@ func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bo
 		if spec == nil {
 			t.Fatal("Failed to locate spec.")
 		}
-		run(t, before...)
 		defer run(t, after...)
+		run(t, before...)
 		run(t, spec)
 	})
 }


### PR DESCRIPTION
Currently if anything in the before block calls t.FailNow (like t.Fatal), the after block never executes because it never gets to defer. This is a problem if your `before` block sets up multiple objects and you need to clean all of them up if any fail. 

Example: 
``` golang
func TestObject(t *testing.T) {
    spec.Run(t, "object", func(t *testing.T, when spec.G, it spec.S) {
        it.Before(func() {
            fmt.Println("Before")
            t.Fatal("Custom Fail")
        })
        it.After(func() {
            fmt.Println("After")
        })
        it("should have some default", func() {
            fmt.Println("Test")
        })
    })
}
```
Output, notice that `After` isn't printed:

```bash
=== RUN   TestObject
=== RUN   TestObject/object
=== RUN   TestObject/object/should_have_some_default
Before
--- FAIL: TestObject (0.00s)
    --- FAIL: TestObject/object (0.00s)
        --- FAIL: TestObject/object/should_have_some_default (0.00s)
            main_test.go:13: Custom Fail
FAIL
FAIL	tmp/spec	0.007s
```

Thanks for the library @sclevine , really enjoying working with it so far.