### PR TITLE
Add Var[T], Context()/T() passthrough, Describe/AsContext, and RunAliased

### DIFF
--- a/aliases.go
+++ b/aliases.go
@@ -1,0 +1,17 @@
+package spec
+
+import "testing"
+
+// Aliases returns before, after, and context bound to it.Before, it.After, and describe.AsContext().
+func Aliases(describe G, it S) (before, after func(func()), context G) {
+	return it.Before, it.After, describe.AsContext()
+}
+
+// RunAliased wraps Run, passing before, after, and context (see Aliases) directly as parameters to f -- no per-file alias declaration needed anywhere.
+func RunAliased(t *testing.T, text string, f func(t *testing.T, describe, context G, it S, before, after func(func())), opts ...Option) bool {
+	t.Helper()
+	return Run(t, text, func(t *testing.T, describe G, it S) {
+		before, after, context := Aliases(describe, it)
+		f(t, describe, context, it, before, after)
+	}, opts...)
+}

--- a/aliases_test.go
+++ b/aliases_test.go
@@ -1,0 +1,59 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestAliases(t *testing.T) {
+	spec.Run(t, "Aliases", func(t *testing.T, describe spec.Describe, it spec.S) {
+		before, after, context := spec.Aliases(describe, it)
+
+		var log []string
+		before(func() { log = append(log, "before") })
+		after(func() { log = append(log, "after") })
+
+		context("a nested group", func() {
+			it("runs before, the spec, then after", func() {
+				log = append(log, "spec")
+				t.Cleanup(func() {
+					want := []string{"before", "spec", "after"}
+					if len(log) != len(want) {
+						t.Fatalf("log = %v, want %v", log, want)
+					}
+					for i := range want {
+						if log[i] != want[i] {
+							t.Fatalf("log = %v, want %v", log, want)
+						}
+					}
+				})
+			})
+		})
+	})
+}
+
+func TestRunAliased(t *testing.T) {
+	spec.RunAliased(t, "RunAliased", func(t *testing.T, describe, context spec.Describe, it spec.S, before, after func(func())) {
+		var log []string
+		before(func() { log = append(log, "before") })
+		after(func() { log = append(log, "after") })
+
+		context("a nested group", func() {
+			it("runs before, the spec, then after", func() {
+				log = append(log, "spec")
+				t.Cleanup(func() {
+					want := []string{"before", "spec", "after"}
+					if len(log) != len(want) {
+						t.Fatalf("log = %v, want %v", log, want)
+					}
+					for i := range want {
+						if log[i] != want[i] {
+							t.Fatalf("log = %v, want %v", log, want)
+						}
+					}
+				})
+			})
+		})
+	})
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,42 @@
+package spec_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestContext(t *testing.T) {
+	spec.Run(t, "Context", func(t *testing.T, when spec.G, it spec.S) {
+		it("returns a non-nil, not-yet-canceled context", func() {
+			ctx := it.Context()
+			if ctx == nil {
+				t.Fatal("Context() returned nil")
+			}
+			if ctx.Err() != nil {
+				t.Fatal("context canceled before spec finished:", ctx.Err())
+			}
+		})
+
+		when("Context is read from Before", func() {
+			var ctx context.Context
+			it.Before(func() { ctx = it.Context() })
+
+			it("captured a non-nil context", func() {
+				if ctx == nil {
+					t.Fatal("Context() returned nil when called from Before")
+				}
+			})
+		})
+
+		it("cancels the context before Cleanup runs", func() {
+			ctx := it.Context()
+			t.Cleanup(func() {
+				if ctx.Err() == nil {
+					t.Error("expected context to be canceled by Cleanup time")
+				}
+			})
+		})
+	})
+}

--- a/describe_test.go
+++ b/describe_test.go
@@ -1,0 +1,17 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestAsContext(t *testing.T) {
+	spec.Run(t, "AsContext", func(t *testing.T, describe spec.Describe, it spec.S) {
+		context := describe.AsContext()
+
+		context("runs specs exactly like describe", func() {
+			it("gets here", func() {})
+		})
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/sclevine/spec
 
-go 1.13
+go 1.24

--- a/options.go
+++ b/options.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"context"
 	"io"
 	"testing"
 )
@@ -194,6 +195,8 @@ type config struct {
 	after  bool
 	t      *testing.T
 	out    func(io.Writer)
+	ctx    func(context.Context)
+	realT  func(*testing.T)
 	report Reporter
 }
 

--- a/parser.go
+++ b/parser.go
@@ -38,7 +38,7 @@ func (n *node) parse(f func(*testing.T, G, S)) Plan {
 		f()
 	}, func(text string, _ func(), opts ...Option) {
 		cfg := options(opts).apply()
-		if cfg.before || cfg.after || cfg.out != nil {
+		if cfg.before || cfg.after || cfg.out != nil || cfg.ctx != nil || cfg.realT != nil {
 			return
 		}
 		n.add(text, cfg, nil)

--- a/spec.go
+++ b/spec.go
@@ -2,6 +2,7 @@ package spec
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"testing"
 	"time"
@@ -14,6 +15,14 @@ import (
 // Sequential, Random, Reverse, Parallel
 // Local, Global, Flat, Nested
 type G func(text string, f func(), opts ...Option)
+
+// Describe is an alias for G, identical in every way -- it exists only so a
+// suite can name its outermost group func(t, describe Describe, it S) to
+// match the describe/it naming this account uses in Quick and Kotest specs.
+type Describe = G
+
+// AsContext returns g unchanged -- names a local alias (context := describe.AsContext()) for a nested group read as RSpec's context rather than a top-level describe.
+func (g G) AsContext() G { return g }
 
 // Pend skips all specs in the provided group.
 //
@@ -74,6 +83,28 @@ func (s S) Out() io.Writer {
 		}
 	})
 	return out
+}
+
+// Context returns the spec's context.Context (nil outside S), canceled when the spec completes -- see (*testing.T).Context.
+func (s S) Context() context.Context {
+	var ctx context.Context
+	s("", nil, func(c *config) {
+		c.ctx = func(v context.Context) {
+			ctx = v
+		}
+	})
+	return ctx
+}
+
+// T returns the current spec's *testing.T (nil outside S), giving Before/After the TempDir/Setenv/Skip access GinkgoT() gives Ginkgo specs.
+func (s S) T() *testing.T {
+	var t *testing.T
+	s("", nil, func(c *config) {
+		c.realT = func(v *testing.T) {
+			t = v
+		}
+	})
+	return t
 }
 
 // Suite defines a top-level group of specs within a suite.
@@ -238,6 +269,10 @@ func Run(t *testing.T, text string, f func(*testing.T, G, S), opts ...Option) bo
 			switch {
 			case cfg.out != nil:
 				cfg.out(buffer)
+			case cfg.ctx != nil:
+				cfg.ctx(t.Context())
+			case cfg.realT != nil:
+				cfg.realT(t)
 			case cfg.before:
 				hooks.before(f)
 			case cfg.after:

--- a/t_test.go
+++ b/t_test.go
@@ -1,0 +1,27 @@
+package spec_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestT(t *testing.T) {
+	spec.Run(t, "T", func(t *testing.T, when spec.G, it spec.S) {
+		when("TempDir is called from Before, mirroring GinkgoT().TempDir()", func() {
+			var dir string
+			it.Before(func() { dir = it.T().TempDir() })
+
+			it("returns a real, existing directory", func() {
+				info, err := os.Stat(dir)
+				if err != nil {
+					t.Fatalf("TempDir() dir doesn't exist: %v", err)
+				}
+				if !info.IsDir() {
+					t.Fatalf("TempDir() returned a non-directory: %s", dir)
+				}
+			})
+		})
+	})
+}

--- a/var.go
+++ b/var.go
@@ -1,0 +1,30 @@
+package spec
+
+// Var holds a value shared between a Before hook and the it blocks that read it.
+// Declaring one fresh inside a G body gets automatic per-spec freshness for
+// free from spec's own re-evaluation model; what Var adds on top is a clear
+// panic on Get before Set, instead of a silent zero value.
+type Var[T any] struct {
+	name string
+	val  T
+	set  bool
+}
+
+// NewVar declares a Var; name appears in the panic message if Get runs before Set.
+func NewVar[T any](name string) *Var[T] {
+	return &Var[T]{name: name}
+}
+
+// Set stores a value, usually called from Before.
+func (v *Var[T]) Set(val T) {
+	v.val = val
+	v.set = true
+}
+
+// Get returns the stored value, panicking if called before Set in this spec.
+func (v *Var[T]) Get() T {
+	if !v.set {
+		panic("spec: " + v.name + " read before Set")
+	}
+	return v.val
+}

--- a/var_test.go
+++ b/var_test.go
@@ -1,0 +1,53 @@
+package spec_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+)
+
+func TestVar(t *testing.T) {
+	spec.Run(t, "Var", func(t *testing.T, when spec.G, it spec.S) {
+		when("Set then Get", func() {
+			v := spec.NewVar[int]("count")
+			it.Before(func() { v.Set(5) })
+
+			it("returns the stored value", func() {
+				if v.Get() != 5 {
+					t.Errorf("Get() = %d, want 5", v.Get())
+				}
+			})
+		})
+
+		when("Get before Set", func() {
+			v := spec.NewVar[int]("count")
+
+			it("panics with a clear message", func() {
+				defer func() {
+					if recover() == nil {
+						t.Fatal("expected Get to panic before Set")
+					}
+				}()
+				v.Get()
+			})
+		})
+
+		when("re-evaluated fresh per spec, not once per when", func() {
+			v := spec.NewVar[int]("count")
+			it.Before(func() { v.Set(0) })
+
+			it("mutates in the first it", func() {
+				v.Set(v.Get() + 1)
+				if v.Get() != 1 {
+					t.Errorf("Get() = %d, want 1", v.Get())
+				}
+			})
+
+			it("does not see the first it's mutation", func() {
+				if v.Get() != 0 {
+					t.Errorf("Get() = %d, want 0 -- Var did not reset fresh for this it", v.Get())
+				}
+			})
+		})
+	})
+}


### PR DESCRIPTION
## Summary

Four small additions that Go's evolution since this project's last release (2019) now makes possible, without changing anything about the existing design -- no global state, no assertion library opinion, no reimplemented `testing` behavior:

- **`S.Context()` / `S.T()`** -- side-channel accessors, built the same way the existing `Out()` already works, that pass through the real `t.Context()` and `*testing.T` for the running subtest. Lets `Before`/`After` bodies call `t.TempDir()`, `t.Skip()`, or hand a real `context.Context` to code under test, without spec needing lifecycle/assertion features of its own.
- **`Describe` / `G.AsContext()`** -- `Describe` is a plain type alias for `G`; `AsContext()` is a no-op method returning the same `G` under a second name. Gives RSpec's `describe`/`context` duality without a second type alias colliding with `S.Context()` above.
- **`Var[T]`** -- a generics-based typed box (`NewVar[T]`, `.Set`, `.Get`) for sharing a value between a `Before` and its sibling `it` blocks, panicking with a named error on a read-before-set instead of silently handing back a zero value.
- **`Aliases` / `RunAliased`** -- `RunAliased` wraps `Run` and passes `describe`, `context`, `it`, `before`, `after` directly as callback parameters, removing the one-line alias boilerplate every consuming file currently needs.

None of this was possible at the project's last release: `Var[T]` needs generics (Go 1.18), and `S.Context()` needs `t.Context()` (Go 1.24). `go.mod`'s `go` directive moves from `1.13` to `1.24` accordingly -- the one change here that isn't purely additive.

## Why

Came out of migrating a real Ginkgo/Gomega test suite (`github.com/woodie/lambada`, both binaries, 55 specs) onto `spec` plus a small new matcher library (`github.com/woodie/expect`, a generics-based Gomega alternative). `spec`'s core design held up completely; these four additions are what closed the gap between what Go could do in 2019 and what it can do now.

## Compatibility

No existing API changed -- every addition here is net-new. Verified against the real `lambada` migration end to end, not just this repo's own test suite.

## Try it now

A tagged, working version of everything above is live today at [github.com/woodie/spec](https://github.com/woodie/spec) (`v0.1.0`), kept at this same import path (`github.com/sclevine/spec`) via a `go.mod` `replace` directive, if you'd rather try it directly than review a diff.

## Splitting this up

Happy to split any of these four into separate PRs if that's easier to review or merge incrementally -- opening with the full picture first since they were designed together, but none of them depend on all the others landing at once except `RunAliased`, which builds on `AsContext()`.
